### PR TITLE
Balance economy and cap offline earnings

### DIFF
--- a/plantlifeapp/plantlifeapp/Models/Plant.swift
+++ b/plantlifeapp/plantlifeapp/Models/Plant.swift
@@ -56,7 +56,8 @@ final class Plant {
 
     var coinsPerMinute: Double {
         let lvl = Double(max(1, level))
-        return baseCoinsPerMinute * pow(lvl, 1.25)
+        let raw = baseCoinsPerMinute * pow(lvl, 1.10)   // gentle growth
+        return min(raw, 250)                            // hard cap to keep it sane
     }
 
     var growthStageLabel: String {


### PR DESCRIPTION
Summary
- Slows early-game coin generation
- Prevents runaway growth and extreme coin rates
- Caps offline earnings to avoid inflated saves

Changes
- Adjust plant coinsPerMinute scaling to a gentler curve
- Tune seeded plant baseCoinsPerMinute and growth interval
- Add/adjust offline caps in GameStore to keep values stable
